### PR TITLE
Silence noisy std::io::ErrorKind::WouldBlock error

### DIFF
--- a/crates/findex-daemon/src/main.rs
+++ b/crates/findex-daemon/src/main.rs
@@ -5,6 +5,7 @@ use nix::time::ClockId;
 use shellexpand::tilde;
 use std::ffi::OsStr;
 use std::fs::{create_dir, File};
+use std::io::ErrorKind;
 use std::path::Path;
 use std::time::Duration;
 use subprocess::{ExitStatus, Popen, PopenConfig, Redirection};
@@ -64,6 +65,7 @@ fn findex_daemon(current_time: time_t) {
                     findex_process = spawn_findex(findex_output.try_clone().unwrap());
                 }
             }
+            Err(e) if e.kind() == ErrorKind::WouldBlock => continue,
             Err(e) => println!("[WARN] Inotify error: {e}"),
         }
     }


### PR DESCRIPTION
This error is expected when inotify is unable to watch a file or directory due to blocking behavior that would occur.  This happens because the `inotify::Inotify::read_events()` function calls `inotify::util::read_into_buffer()` (which then directly calls the OS-level `read` via `ffi::read()`), and propagates any `Error` encountered.

This change silences the error message to avoid unnecessary log spam.

See: hannobraun/inotify-rs#215