### PR TITLE
Add SystemD service

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ check instructions from the `release` branch.
 - Copy `target/release/findex` to `/usr/bin/`
 - Copy `targer/release/findex-daemon` to `/usr/bin/`
 - Add `findex-daemon` to autostart/startup applications
+  - If using SystemD, enable & start the `findex-daemon` user service
+
+        sudo systemctl enable --user findex-daemon.service
+        sudo systemctl start --user findex-daemon.service
 
 ### Installation from AUR
 

--- a/service/findex-daemon.service
+++ b/service/findex-daemon.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Findex Daemon
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=forking
+ExitType=main
+ExecStart=/usr/bin/findex-daemon
+Restart=on-failure
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
This adds a SystemD user service for `findex-daemon`.  When enabled, it starts linked to `graphical-session.target`.  This should be relatively desktop agnostic, except for users who don't use SystemD at all.  Otherwise, for SystemD systems it's simple to enable it:

```console
$ systemctl enable --user findex-daemon.service
Created symlink '/home/exampleuser/.config/systemd/user/graphical-session.target.wants/findex-daemon.service' → '/usr/lib/systemd/user/findex-daemon.service'.
```

On next graphical session start, the `findex-daemon` will automatically start along with it.  To manually start for the first time after installing the `.service` unit:

```console
$ systemctl start --user findex-daemon.service
```

```console
$ systemctl status --user findex-daemon.service
● findex-daemon.service - Findex Daemon
     Loaded: loaded (/usr/lib/systemd/user/findex-daemon.service; enabled; preset: enabled)
     Active: active (running) since Thu 2024-08-08 19:05:40 MDT; 3s ago
 Invocation: ad44a88b0876459880a31ed8da377289
    Process: 3020878 ExecStart=/usr/bin/findex-daemon (code=exited, status=0/SUCCESS)
   Main PID: 3020888 (findex-daemon)
      Tasks: 10 (limit: 76959)
     Memory: 40.7M (peak: 44.6M)
        CPU: 742ms
     CGroup: /user.slice/user-1000.slice/user@1000.service/app.slice/findex-daemon.service
             ├─3020888 /usr/bin/findex-daemon
             └─3020889 findex

Aug 08 19:05:39 saturn systemd[970]: Starting Findex Daemon...
Aug 08 19:05:40 saturn systemd[970]: Started Findex Daemon.
```