### PR TITLE
Exit installer script earlier when the binary build fails

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -6,6 +6,11 @@ do_installation() {
     echo "Building Findex..."
     cargo build --release
 
+    if [[ $? -ne 0 ]]; then
+        echo "Findex failed to build."
+        exit 1
+    fi
+
     echo "Copying files..."
     sudo cp target/release/findex /usr/bin/findex
     sudo cp target/release/findex-daemon /usr/bin/findex-daemon


### PR DESCRIPTION
Thanks for this awesome project. I started to use Findex recently, and it works like a charm.

I found  a small issue with the `installer.sh` script  which continue to proceed when the `cargo build --release` failed (due to various reasons such as missing required library.)

This small patch to the `installer.sh` will exit this script earlier if `cargo build` fails.