### PR TITLE
Add multi-monitor support by allowing the user to specify which monitor findex should open on

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ check instructions from the `release` branch.
 
 ### Installation from AUR
 
-From repo: `findex-git`   
+From repo: `findex-git`
 Prebuilt: `findex-bin`
 
 After that, add `findex-daemon` to autostart/startup applications
@@ -141,6 +141,7 @@ Behaviour can be changed by modifying `~/.config/findex/settings.toml`. If there
 | close_window_on_losing_focus | Close window when it loses focus                                                                                         | Boolean |
 | icon_size                    | Icon width and height will be set from this value                                                                        | Integer |
 | entry_icon                   | Icon displayed beside the searchbar                                                                                      | String  |
+| on_monitor                   | The monitor that findex is opened on (zero indexed)                                                                      | Integer |
 
 
 ## Plugins
@@ -178,16 +179,16 @@ use abi_stable::std_types::*;
 fn init(config: &RHashMap<RString, RString>) -> RResult<(), RString>  {
     // Set up your plugin using the config if necessary
     // Return RErr if something went wrong
-    
+
     // Returning this indicates that the plugin initialization is successful
     ROk(())
 }
 
 fn handle_query(query: RStr) -> RVec<FResult> {
     let mut result = vec![];
-    
+
     /* Do stuff here */
-    
+
     RVec::from(result)
 }
 

--- a/crates/findex/src/config.rs
+++ b/crates/findex/src/config.rs
@@ -41,6 +41,7 @@ pub struct FindexConfig {
     /// This should get filled after configuration gets initialized
     #[serde(skip)]
     pub plugin_definitions: HashMap<RString, PluginDefinition>,
+    pub on_monitor: ROption<i32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -69,6 +70,7 @@ impl Default for FindexConfig {
             error: RString::new(),
             plugins: HashMap::new(),
             plugin_definitions: HashMap::new(),
+            on_monitor: RNone,
         }
     }
 }

--- a/crates/findex/src/gui/mod.rs
+++ b/crates/findex/src/gui/mod.rs
@@ -10,6 +10,7 @@ use crate::gui::result_list::{result_list_clear, result_list_new};
 use crate::gui::result_list_row::handle_enter;
 use crate::gui::searchbox::searchbox_new;
 use crate::show_dialog;
+use abi_stable::std_types::*;
 use findex_plugin::findex_internal::KeyboardShortcut;
 use gtk::builders::BoxBuilder;
 use gtk::gdk::{EventKey, EventMask, ModifierType, Screen};
@@ -211,16 +212,24 @@ impl GUI {
 
     fn position_window(window: &Window) {
         let display = gdk::Display::default().unwrap();
-        let monitor_geo = display
-            .monitor_at_window(&window.window().unwrap())
-            .unwrap()
-            .geometry();
+
+        let monitor_geo = if let RSome(on_monitor) = FINDEX_CONFIG.on_monitor {
+            display
+                .monitor(on_monitor.abs() % display.n_monitors())
+                .unwrap()
+                .geometry()
+        } else {
+            display.primary_monitor().unwrap().geometry()
+        };
+
         let screen_height = monitor_geo.height() as f32;
         let screen_width = monitor_geo.width() as f32;
+        let screen_x = monitor_geo.x() as f32;
+        let screen_y = monitor_geo.y() as f32;
 
         window.move_(
-            (screen_width * 0.5 - (window.allocation().width() / 2) as f32) as i32,
-            (screen_height * 0.3) as i32,
+            ((screen_width * 0.5 - (window.allocation().width() / 2) as f32) + screen_x) as i32,
+            ((screen_height * 0.3) + screen_y) as i32,
         );
     }
 


### PR DESCRIPTION
When using a multi-monitor setup, findex would not open on the primary monitor if another monitor was positioned directly above it.

I believe the changes to the `window.move_()` arguments in `GUI::position_window` alone would fix this but I'm sure others may want findex to open on a monitor other than their primary one, so I added a config setting to allow the user to specify which monitor findex should open on.

I haven't tested this in Wayland, so that will need to be tested.