### PR TITLE
Mitigate crashes on arch (and probably more distros) by handling when no monitor could be returned.

### DIFF
--- a/crates/findex/src/gui/mod.rs
+++ b/crates/findex/src/gui/mod.rs
@@ -213,13 +213,16 @@ impl GUI {
     fn position_window(window: &Window) {
         let display = gdk::Display::default().unwrap();
 
-        let monitor_geo = if let RSome(on_monitor) = FINDEX_CONFIG.on_monitor {
-            display
-                .monitor(on_monitor.abs() % display.n_monitors())
-                .unwrap()
-                .geometry()
+        let monitor = if let RSome(on_monitor) = FINDEX_CONFIG.on_monitor {
+            display.monitor(on_monitor.abs() % display.n_monitors())
         } else {
-            display.primary_monitor().unwrap().geometry()
+            display.primary_monitor()
+        };
+
+        let monitor_geo = if let Some(monitor) = monitor {
+            monitor.geometry()
+        } else {
+            return;
         };
 
         let screen_height = monitor_geo.height() as f32;


### PR DESCRIPTION
I forgot to handle when no monitor could be returned and unwrapped the `Option` regardless, resulting in #70.

I'll mark this request ready for review when the pull request is tested by those affected.