### PR TITLE
Add SystemD service restart limit

### DIFF
--- a/service/findex-daemon.service
+++ b/service/findex-daemon.service
@@ -8,6 +8,12 @@ Type=forking
 ExitType=main
 ExecStart=/usr/bin/findex-daemon
 Restart=on-failure
+# Exponential CrashLoop Backoff
+RestartSteps=5
+RestartMaxDelaySec=60s
+# Give up after 6 tries
+StartLimitInterval=infinity
+StartLimitBurst=6
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
Note: This should limit the impact of a crashloop filling up `~/.findex-logs/` disk space.
